### PR TITLE
Sj/more additions

### DIFF
--- a/custom_components/osrs_data/account_store.py
+++ b/custom_components/osrs_data/account_store.py
@@ -84,14 +84,9 @@ class AccountState:
                 or old.get("level") != new_level
                 or skill_name not in self.skills
             ):
-                self.detail_sensors[f"{skill_name} XP"] = {
-                    "value": new_xp,
-                    "attributes": {"skill": skill_name},
-                    "last_update": now,
-                }
-                self.detail_sensors[f"{skill_name} Level"] = {
+                self.detail_sensors[skill_name] = {
                     "value": new_level,
-                    "attributes": {"skill": skill_name},
+                    "attributes": {"xp": new_xp},
                     "last_update": now,
                 }
 

--- a/custom_components/osrs_data/account_store.py
+++ b/custom_components/osrs_data/account_store.py
@@ -39,6 +39,9 @@ class AccountState:
         # Location: {x: int, y: int, plane: int}
         self.location: dict[str, int] = {"x": 0, "y": 0, "plane": 0}
 
+        # Spellbook: {id: int, name: str}
+        self.spellbook: dict[str, Any] = {"id": 0, "name": ""}
+
         # Events: list (future use, initially empty)
         self.events: list[Any] = []
 
@@ -67,6 +70,7 @@ class AccountState:
         self.health = parsed.get("health", {"current": 0, "max": 0})
         self.prayer = parsed.get("prayer", {"current": 0, "max": 0})
         self.location = parsed.get("location", {"x": 0, "y": 0, "plane": 0})
+        self.spellbook = parsed.get("spellbook", {"id": 0, "name": ""})
 
         # Update skills and detail sensors
         new_skills = parsed.get("skills", {})
@@ -106,6 +110,7 @@ class AccountState:
             "health": self.health,
             "prayer": self.prayer,
             "location": self.location,
+            "spellbook": self.spellbook,
             "events": self.events,
             "detail_sensors": self.detail_sensors,
             "last_update": self.last_update,
@@ -122,6 +127,7 @@ class AccountState:
         self.health = data.get("health", {"current": 0, "max": 0})
         self.prayer = data.get("prayer", {"current": 0, "max": 0})
         self.location = data.get("location", {"x": 0, "y": 0, "plane": 0})
+        self.spellbook = data.get("spellbook", {"id": 0, "name": ""})
         self.events = data.get("events", [])
         self.detail_sensors = data.get("detail_sensors", {})
         self.last_update = data.get("last_update")

--- a/custom_components/osrs_data/account_store.py
+++ b/custom_components/osrs_data/account_store.py
@@ -33,8 +33,8 @@ class AccountState:
         # Health: {current: int, max: int}
         self.health: dict[str, int] = {"current": 0, "max": 0}
 
-        # Prayer: {current: int, max: int}
-        self.prayer: dict[str, int] = {"current": 0, "max": 0}
+        # Prayer Points: {current: int, max: int}
+        self.prayer_points: dict[str, int] = {"current": 0, "max": 0}
 
         # Location: {x: int, y: int, plane: int}
         self.location: dict[str, int] = {"x": 0, "y": 0, "plane": 0}
@@ -68,7 +68,7 @@ class AccountState:
         self.inventory = parsed.get("inventory", [])
         self.equipment = parsed.get("equipment", {})
         self.health = parsed.get("health", {"current": 0, "max": 0})
-        self.prayer = parsed.get("prayer", {"current": 0, "max": 0})
+        self.prayer_points = parsed.get("prayerPoints", {"current": 0, "max": 0})
         self.location = parsed.get("location", {"x": 0, "y": 0, "plane": 0})
         self.spellbook = parsed.get("spellbook", {"id": 0, "name": ""})
 
@@ -103,7 +103,7 @@ class AccountState:
             "inventory": self.inventory,
             "equipment": self.equipment,
             "health": self.health,
-            "prayer": self.prayer,
+            "prayerPoints": self.prayer_points,
             "location": self.location,
             "spellbook": self.spellbook,
             "events": self.events,
@@ -120,7 +120,7 @@ class AccountState:
         self.inventory = data.get("inventory", [])
         self.equipment = data.get("equipment", {})
         self.health = data.get("health", {"current": 0, "max": 0})
-        self.prayer = data.get("prayer", {"current": 0, "max": 0})
+        self.prayer_points = data.get("prayerPoints", {"current": 0, "max": 0})
         self.location = data.get("location", {"x": 0, "y": 0, "plane": 0})
         self.spellbook = data.get("spellbook", {"id": 0, "name": ""})
         self.events = data.get("events", [])

--- a/custom_components/osrs_data/parser/base.py
+++ b/custom_components/osrs_data/parser/base.py
@@ -106,6 +106,15 @@ def parse(payload: dict[str, Any]) -> dict[str, Any] | None:
             "plane": location_data.get("plane", 0),
         }
 
+    # ── Spellbook ────────────────────────────────────────────────────
+    spellbook: dict[str, Any] = {"id": 0, "name": ""}
+    spellbook_data = player.get("spellbook")
+    if isinstance(spellbook_data, dict):
+        spellbook = {
+            "id": spellbook_data.get("id", 0),
+            "name": spellbook_data.get("name", ""),
+        }
+
     # ── Events (future use, initially empty) ─────────────────────────
     events = player.get("events", [])
     if not isinstance(events, list):
@@ -121,5 +130,6 @@ def parse(payload: dict[str, Any]) -> dict[str, Any] | None:
         "health": health,
         "prayer": prayer,
         "location": location,
+        "spellbook": spellbook,
         "events": events,
     }

--- a/custom_components/osrs_data/parser/base.py
+++ b/custom_components/osrs_data/parser/base.py
@@ -87,11 +87,11 @@ def parse(payload: dict[str, Any]) -> dict[str, Any] | None:
             "max": health_data.get("max", 0),
         }
 
-    # ── Prayer ────────────────────────────────────────────────────────
-    prayer: dict[str, int] = {"current": 0, "max": 0}
-    prayer_data = player.get("prayer")
+    # ── Prayer Points ─────────────────────────────────────────────────
+    prayer_points: dict[str, int] = {"current": 0, "max": 0}
+    prayer_data = player.get("prayerPoints")
     if isinstance(prayer_data, dict):
-        prayer = {
+        prayer_points = {
             "current": prayer_data.get("current", 0),
             "max": prayer_data.get("max", 0),
         }
@@ -128,7 +128,7 @@ def parse(payload: dict[str, Any]) -> dict[str, Any] | None:
         "inventory": inventory,
         "equipment": equipment,
         "health": health,
-        "prayer": prayer,
+        "prayerPoints": prayer_points,
         "location": location,
         "spellbook": spellbook,
         "events": events,

--- a/custom_components/osrs_data/sensor.py
+++ b/custom_components/osrs_data/sensor.py
@@ -57,7 +57,7 @@ async def async_setup_entry(
             new_entities.append(OsrsInventorySensor(entry, state, slug))
             new_entities.append(OsrsEquipmentSensor(entry, state, slug))
             new_entities.append(OsrsHealthSensor(entry, state, slug))
-            new_entities.append(OsrsPrayerSensor(entry, state, slug))
+            new_entities.append(OsrsPrayerPointsSensor(entry, state, slug))
             new_entities.append(OsrsLocationSensor(entry, state, slug))
             new_entities.append(OsrsSpellbookSensor(entry, state, slug))
 
@@ -332,14 +332,14 @@ class OsrsLocationSensor(SensorEntity):
         )
 
 
-# ── Prayer sensor ────────────────────────────────────────────────────
+# ── Prayer Points sensor ─────────────────────────────────────────────
 
 
-class OsrsPrayerSensor(SensorEntity):
+class OsrsPrayerPointsSensor(SensorEntity):
     """Sensor whose state is current prayer points, attributes hold current/max."""
 
     _attr_has_entity_name = True
-    _attr_name = "Prayer"
+    _attr_name = "Prayer Points"
 
     def __init__(
         self,
@@ -349,18 +349,18 @@ class OsrsPrayerSensor(SensorEntity):
     ) -> None:
         self._entry = entry
         self._state = state
-        self._attr_unique_id = f"{state.account_hash}_prayer"
+        self._attr_unique_id = f"{state.account_hash}_prayer_points"
 
     @property
     def native_value(self) -> int:
         """Current prayer points."""
-        return self._state.prayer.get("current", 0)
+        return self._state.prayer_points.get("current", 0)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         attrs: dict[str, Any] = {
-            "current": self._state.prayer.get("current", 0),
-            "max": self._state.prayer.get("max", 0),
+            "current": self._state.prayer_points.get("current", 0),
+            "max": self._state.prayer_points.get("max", 0),
         }
         if self._state.last_update:
             attrs["last_update"] = self._state.last_update

--- a/custom_components/osrs_data/sensor.py
+++ b/custom_components/osrs_data/sensor.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
             new_entities.append(OsrsHealthSensor(entry, state, slug))
             new_entities.append(OsrsPrayerSensor(entry, state, slug))
             new_entities.append(OsrsLocationSensor(entry, state, slug))
+            new_entities.append(OsrsSpellbookSensor(entry, state, slug))
 
         # Create detail sensors for any new keys (skill xp & level)
         for key in state.detail_sensors:
@@ -205,6 +206,56 @@ class OsrsInventorySensor(SensorEntity):
             "items": self._state.inventory,
             "slots_used": len(self._state.inventory),
             "slots_total": 28,
+        }
+        if self._state.last_update:
+            attrs["last_update"] = self._state.last_update
+        return attrs
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        return _account_device_info(self._entry, self._state)
+
+    @callback
+    def _handle_update(self, account_hash: str) -> None:
+        if account_hash == self._state.account_hash:
+            self.async_write_ha_state()
+
+    async def async_added_to_hass(self) -> None:
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_ACCOUNT_UPDATED, self._handle_update
+            )
+        )
+
+
+# ── Spellbook sensor ─────────────────────────────────────────────────
+
+
+class OsrsSpellbookSensor(SensorEntity):
+    """Sensor whose state is the spellbook name, attribute holds the id."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Spellbook"
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        state: AccountState,
+        slug: str,
+    ) -> None:
+        self._entry = entry
+        self._state = state
+        self._attr_unique_id = f"{state.account_hash}_spellbook"
+
+    @property
+    def native_value(self) -> str:
+        """Active spellbook name."""
+        return self._state.spellbook.get("name", "")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        attrs: dict[str, Any] = {
+            "id": self._state.spellbook.get("id", 0),
         }
         if self._state.last_update:
             attrs["last_update"] = self._state.last_update

--- a/manual_tests/mock-data.json
+++ b/manual_tests/mock-data.json
@@ -28,6 +28,10 @@
       "y": 3350,
       "plane": 0
     },
+    "spellbook": {
+      "id": 3,
+      "name": "arceuus"
+    },
     "equipment": {
       "items": [
         { "name": "Fire cape", "gePrice": 0, "haPrice": 0, "quantity": 1, "equipmentSlot": "CAPE" },

--- a/manual_tests/mock-data.json
+++ b/manual_tests/mock-data.json
@@ -19,7 +19,7 @@
       "current": 75,
       "max": 99
     },
-    "prayer": {
+    "prayerPoints": {
       "current": 43,
       "max": 43
     },

--- a/samples/runelite-post-request.md
+++ b/samples/runelite-post-request.md
@@ -56,7 +56,7 @@ X-Osrs-Token: <device-token>
             "current": 75,
             "max": 99
         },
-        "prayer": {
+        "prayerPoints": {
             "current": 43,
             "max": 43
         },
@@ -95,7 +95,7 @@ X-Osrs-Token: <device-token>
 | Player Info | Player name | `account_type`, `world`, `last_update`, `events` |
 | Inventory | Number of items | `items` (list), `slots_used`, `slots_total` (28) |
 | Health | Current hitpoints | `current`, `max`, `last_update` |
-| Prayer | Current prayer points | `current`, `max`, `last_update` |
+| Prayer Points | Current prayer points | `current`, `max`, `last_update` |
 | Location | Tile coordinates (x, y) | `x`, `y`, `plane`, `last_update` |
 | Spellbook | Active spellbook name | `id`, `last_update` |
 | Equipment | Number of equipped slots | One key per slot: `HEAD`, `CAPE`, `WEAPON`, `BODY`, `LEGS`, `GLOVES`, `BOOTS`, `AMMO`, `AMMO_EXTRA`, `AMULET`, `RING`, `SHIELD` |

--- a/samples/runelite-post-request.md
+++ b/samples/runelite-post-request.md
@@ -65,6 +65,10 @@ X-Osrs-Token: <device-token>
             "y": 3350,
             "plane": 0
         },
+        "spellbook": {
+            "id": 3,
+            "name": "arceuus"
+        },
         "equipment": {
             "items": [
                 { "name": "Neitiznot faceguard", "gePrice": 3500000, "haPrice": 60000, "quantity": 1, "equipmentSlot": "HEAD" },
@@ -93,6 +97,7 @@ X-Osrs-Token: <device-token>
 | Health | Current hitpoints | `current`, `max`, `last_update` |
 | Prayer | Current prayer points | `current`, `max`, `last_update` |
 | Location | Tile coordinates (x, y) | `x`, `y`, `plane`, `last_update` |
+| Spellbook | Active spellbook name | `id`, `last_update` |
 | Equipment | Number of equipped slots | One key per slot: `HEAD`, `CAPE`, `WEAPON`, `BODY`, `LEGS`, `GLOVES`, `BOOTS`, `AMMO`, `AMMO_EXTRA`, `AMULET`, `RING`, `SHIELD` |
 | `<Skill> XP` | XP value | `skill` |
 | `<Skill> Level` | Level value | `skill` |

--- a/tests/test_account_persistence.py
+++ b/tests/test_account_persistence.py
@@ -74,11 +74,12 @@ class TestAccountStatePersistence:
         assert restored.account_type == "normal"
         assert restored.world == "302"
         assert restored.last_update is not None
-        assert "Sailing XP" in restored.detail_sensors
-        assert restored.detail_sensors["Sailing XP"]["value"] == 50000
-        assert restored.detail_sensors["Sailing Level"]["value"] == 70
-        assert "Attack XP" in restored.detail_sensors
-        assert restored.detail_sensors["Attack Level"]["value"] == 99
+        assert "Sailing" in restored.detail_sensors
+        assert restored.detail_sensors["Sailing"]["value"] == 70
+        assert restored.detail_sensors["Sailing"]["attributes"]["xp"] == 50000
+        assert "Attack" in restored.detail_sensors
+        assert restored.detail_sensors["Attack"]["value"] == 99
+        assert restored.detail_sensors["Attack"]["attributes"]["xp"] == 13000000
         assert len(restored.inventory) == 1
         assert restored.equipment["HEAD"]["name"] == "Helm"
 
@@ -126,8 +127,9 @@ class TestAccountStorePersistence:
         assert restored is not None
         assert restored.player_name == "PlayerOne"
         assert restored.account_type == "normal"
-        assert "Attack XP" in restored.detail_sensors
-        assert restored.detail_sensors["Attack XP"]["value"] == 1000
+        assert "Attack" in restored.detail_sensors
+        assert restored.detail_sensors["Attack"]["value"] == 70
+        assert restored.detail_sensors["Attack"]["attributes"]["xp"] == 1000
 
     def test_roundtrip_multiple_accounts(self):
         """Multiple accounts roundtrip correctly with separate state."""
@@ -167,5 +169,5 @@ class TestAccountStorePersistence:
 
         restored = store2.get_or_create(None, "RedFuhrbreak")
         assert restored is not None
-        assert restored.detail_sensors["Sailing XP"]["value"] == 50000
-        assert restored.detail_sensors["Sailing Level"]["value"] == 70
+        assert restored.detail_sensors["Sailing"]["value"] == 70
+        assert restored.detail_sensors["Sailing"]["attributes"]["xp"] == 50000

--- a/tests/test_account_store.py
+++ b/tests/test_account_store.py
@@ -64,10 +64,9 @@ class TestAccountState:
         state.update_player_data({
             "skills": {"Attack": {"xp": 1000, "level": 10}},
         })
-        assert "Attack XP" in state.detail_sensors
-        assert "Attack Level" in state.detail_sensors
-        assert state.detail_sensors["Attack XP"]["value"] == 1000
-        assert state.detail_sensors["Attack Level"]["value"] == 10
+        assert "Attack" in state.detail_sensors
+        assert state.detail_sensors["Attack"]["value"] == 10
+        assert state.detail_sensors["Attack"]["attributes"]["xp"] == 1000
 
     def test_update_player_name(self):
         state = AccountState("hash1", "OldName")
@@ -79,7 +78,7 @@ class TestAccountState:
         state.update_player_data({
             "skills": {"Attack": {"xp": 1000, "level": 10}},
         })
-        first_update = state.detail_sensors["Attack XP"]["last_update"]
+        first_update = state.detail_sensors["Attack"]["last_update"]
 
         # Same values — sensor should not be refreshed
         import time
@@ -87,22 +86,22 @@ class TestAccountState:
         state.update_player_data({
             "skills": {"Attack": {"xp": 1000, "level": 10}},
         })
-        assert state.detail_sensors["Attack XP"]["last_update"] == first_update
+        assert state.detail_sensors["Attack"]["last_update"] == first_update
 
     def test_skill_sensor_refreshed_on_change(self):
         state = AccountState("hash1", "Player")
         state.update_player_data({
             "skills": {"Attack": {"xp": 1000, "level": 10}},
         })
-        first_update = state.detail_sensors["Attack XP"]["last_update"]
+        first_update = state.detail_sensors["Attack"]["last_update"]
 
         import time
         time.sleep(0.01)
         state.update_player_data({
             "skills": {"Attack": {"xp": 2000, "level": 10}},
         })
-        assert state.detail_sensors["Attack XP"]["last_update"] != first_update
-        assert state.detail_sensors["Attack XP"]["value"] == 2000
+        assert state.detail_sensors["Attack"]["last_update"] != first_update
+        assert state.detail_sensors["Attack"]["attributes"]["xp"] == 2000
 
 
 class TestAccountStore:
@@ -163,7 +162,7 @@ class TestAccountStore:
             "skills": {"Defence": {"xp": 500, "level": 50}},
         })
 
-        assert "Attack XP" in a.detail_sensors
-        assert "Attack XP" not in b.detail_sensors
-        assert "Defence XP" in b.detail_sensors
-        assert "Defence XP" not in a.detail_sensors
+        assert "Attack" in a.detail_sensors
+        assert "Attack" not in b.detail_sensors
+        assert "Defence" in b.detail_sensors
+        assert "Defence" not in a.detail_sensors

--- a/tests/test_detail_sensors.py
+++ b/tests/test_detail_sensors.py
@@ -41,11 +41,9 @@ class TestDetailSensorsSkills:
         state.update_player_data({
             "skills": {"Attack": {"xp": 737627, "level": 60}},
         })
-        assert "Attack XP" in state.detail_sensors
-        assert "Attack Level" in state.detail_sensors
-        assert state.detail_sensors["Attack XP"]["value"] == 737627
-        assert state.detail_sensors["Attack Level"]["value"] == 60
-        assert state.detail_sensors["Attack XP"]["attributes"]["skill"] == "Attack"
+        assert "Attack" in state.detail_sensors
+        assert state.detail_sensors["Attack"]["value"] == 60
+        assert state.detail_sensors["Attack"]["attributes"]["xp"] == 737627
 
     def test_creates_sensors_for_multiple_skills(self):
         state = AccountState("hash1", "Player")
@@ -55,12 +53,12 @@ class TestDetailSensorsSkills:
                 "Defence": {"xp": 2000, "level": 20},
             },
         })
-        assert "Attack XP" in state.detail_sensors
-        assert "Attack Level" in state.detail_sensors
-        assert "Defence XP" in state.detail_sensors
-        assert "Defence Level" in state.detail_sensors
-        assert state.detail_sensors["Attack XP"]["value"] == 1000
-        assert state.detail_sensors["Defence Level"]["value"] == 20
+        assert "Attack" in state.detail_sensors
+        assert "Defence" in state.detail_sensors
+        assert state.detail_sensors["Attack"]["value"] == 10
+        assert state.detail_sensors["Attack"]["attributes"]["xp"] == 1000
+        assert state.detail_sensors["Defence"]["value"] == 20
+        assert state.detail_sensors["Defence"]["attributes"]["xp"] == 2000
 
     def test_updates_existing_skill_sensor(self):
         state = AccountState("hash1", "Player")
@@ -70,8 +68,8 @@ class TestDetailSensorsSkills:
         state.update_player_data({
             "skills": {"Attack": {"xp": 2000, "level": 11}},
         })
-        assert state.detail_sensors["Attack XP"]["value"] == 2000
-        assert state.detail_sensors["Attack Level"]["value"] == 11
+        assert state.detail_sensors["Attack"]["value"] == 11
+        assert state.detail_sensors["Attack"]["attributes"]["xp"] == 2000
 
     def test_no_skills_no_detail_sensors(self):
         state = AccountState("hash1", "Player")
@@ -94,10 +92,10 @@ class TestDetailSensorsSkills:
                 "Magic": {"xp": 400, "level": 40},
             },
         })
-        # 4 skills × 2 sensors each = 8 detail sensors
-        assert len(state.detail_sensors) == 8
-        assert state.detail_sensors["Magic XP"]["value"] == 400
-        assert state.detail_sensors["Magic Level"]["value"] == 40
+        # 4 skills × 1 sensor each = 4 detail sensors
+        assert len(state.detail_sensors) == 4
+        assert state.detail_sensors["Magic"]["value"] == 40
+        assert state.detail_sensors["Magic"]["attributes"]["xp"] == 400
 
     def test_unchanged_skill_not_refreshed(self):
         """If XP and level are the same, the sensor should not be refreshed."""
@@ -105,29 +103,29 @@ class TestDetailSensorsSkills:
         state.update_player_data({
             "skills": {"Attack": {"xp": 1000, "level": 10}},
         })
-        first_ts = state.detail_sensors["Attack XP"]["last_update"]
+        first_ts = state.detail_sensors["Attack"]["last_update"]
 
         import time
         time.sleep(0.01)
         state.update_player_data({
             "skills": {"Attack": {"xp": 1000, "level": 10}},
         })
-        assert state.detail_sensors["Attack XP"]["last_update"] == first_ts
+        assert state.detail_sensors["Attack"]["last_update"] == first_ts
 
     def test_xp_change_triggers_refresh(self):
         state = AccountState("hash1", "Player")
         state.update_player_data({
             "skills": {"Attack": {"xp": 1000, "level": 10}},
         })
-        first_ts = state.detail_sensors["Attack XP"]["last_update"]
+        first_ts = state.detail_sensors["Attack"]["last_update"]
 
         import time
         time.sleep(0.01)
         state.update_player_data({
             "skills": {"Attack": {"xp": 1500, "level": 10}},
         })
-        assert state.detail_sensors["Attack XP"]["value"] == 1500
-        assert state.detail_sensors["Attack XP"]["last_update"] != first_ts
+        assert state.detail_sensors["Attack"]["attributes"]["xp"] == 1500
+        assert state.detail_sensors["Attack"]["last_update"] != first_ts
 
 
 class TestInventoryAndEquipment:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -174,7 +174,7 @@ class TestEventsIntegration:
         acct = store.get_or_create(None, "PlayerOne")
         assert acct.account_type == "normal"
         assert acct.world == "302"
-        assert "Attack XP" in acct.detail_sensors
+        assert "Attack" in acct.detail_sensors
 
     @pytest.mark.asyncio
     async def test_multi_account_separate_state(self):
@@ -190,8 +190,8 @@ class TestEventsIntegration:
 
         assert acct_a.account_type == "normal"
         assert acct_b.account_type == "iron"
-        assert "Attack XP" in acct_a.detail_sensors
-        assert "Defence XP" in acct_b.detail_sensors
+        assert "Attack" in acct_a.detail_sensors
+        assert "Defence" in acct_b.detail_sensors
 
     @pytest.mark.asyncio
     async def test_same_account_multiple_updates(self):
@@ -203,8 +203,8 @@ class TestEventsIntegration:
         await view.post(_make_json_request(hass, PLAYER_ONE_UPDATED_PAYLOAD, token))
 
         acct = store.get_or_create(None, "PlayerOne")
-        assert acct.detail_sensors["Attack XP"]["value"] == 900000
-        assert acct.detail_sensors["Attack Level"]["value"] == 70
+        assert acct.detail_sensors["Attack"]["value"] == 70
+        assert acct.detail_sensors["Attack"]["attributes"]["xp"] == 900000
 
     @pytest.mark.asyncio
     async def test_dispatcher_signal_fired(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -212,24 +212,15 @@ class TestOsrsEquipmentSensor:
 class TestOsrsAccountDetailSensor:
     """Tests for the per-skill detail sensor."""
 
-    def test_skill_xp_sensor(self):
+    def test_skill_sensor(self):
         entry = _make_entry()
         state = AccountState("hash1", "Player")
         state.update_player_data({
             "skills": {"Attack": {"xp": 737627, "level": 60}},
         })
-        sensor = OsrsAccountDetailSensor(entry, state, "hash1", "Attack XP")
-        assert sensor.native_value == 737627
-        assert sensor.extra_state_attributes["skill"] == "Attack"
-
-    def test_skill_level_sensor(self):
-        entry = _make_entry()
-        state = AccountState("hash1", "Player")
-        state.update_player_data({
-            "skills": {"Attack": {"xp": 737627, "level": 60}},
-        })
-        sensor = OsrsAccountDetailSensor(entry, state, "hash1", "Attack Level")
+        sensor = OsrsAccountDetailSensor(entry, state, "hash1", "Attack")
         assert sensor.native_value == 60
+        assert sensor.extra_state_attributes["xp"] == 737627
 
     def test_unique_id(self):
         entry = _make_entry()
@@ -237,8 +228,8 @@ class TestOsrsAccountDetailSensor:
         state.update_player_data({
             "skills": {"Attack": {"xp": 100, "level": 10}},
         })
-        sensor = OsrsAccountDetailSensor(entry, state, "hash1", "Attack XP")
-        assert "hash1_detail_attack_xp" == sensor.unique_id
+        sensor = OsrsAccountDetailSensor(entry, state, "hash1", "Attack")
+        assert "hash1_detail_attack" == sensor.unique_id
 
     def test_no_dink_in_device_info(self):
         """Ensure no Dink references in device info."""


### PR DESCRIPTION
This pull request introduces two main improvements: it adds support for tracking the player's active spellbook and refactors the handling of prayer points and skill detail sensors for clarity and consistency. The changes affect the data model, sensor entities, parsing logic, tests, and documentation.

**Key changes:**

### Spellbook Support
- Added tracking of the player's active spellbook (with `id` and `name`) to the data model, parsing logic, sensor entities, mock/test data, and documentation. A new `OsrsSpellbookSensor` entity was introduced to expose this information. [[1]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L36-R44) [[2]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L68-R73) [[3]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L107-R108) [[4]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L123-R125) [[5]](diffhunk://#diff-2515234a7bf3cac7ccee7706f5f52b56d1aba399c120b6c79a2f455208881c3eR109-R117) [[6]](diffhunk://#diff-2515234a7bf3cac7ccee7706f5f52b56d1aba399c120b6c79a2f455208881c3eL122-R133) [[7]](diffhunk://#diff-c01a108b5fa41b9b6eee6bf0537f7b2c6dafb232acef3af4b32e0d05e7e8725aL60-R62) [[8]](diffhunk://#diff-c01a108b5fa41b9b6eee6bf0537f7b2c6dafb232acef3af4b32e0d05e7e8725aR231-R280) [[9]](diffhunk://#diff-8c132bb66f8ce0075d07f66086b9909698dee469a625e946161c28a53f40f99dR31-R34) [[10]](diffhunk://#diff-1d01643e718f913f22711cf2f091b1b00bc5d479d99d35cd055979cf4c9f1736R68-R71) [[11]](diffhunk://#diff-1d01643e718f913f22711cf2f091b1b00bc5d479d99d35cd055979cf4c9f1736L94-R100)

### Prayer Points Refactor
- Renamed all references from `prayer` to `prayer_points` (and from `"prayer"` to `"prayerPoints"` in JSON), updated the parser, state, and sensor entity accordingly, and renamed the sensor class to `OsrsPrayerPointsSensor` for clarity. [[1]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L36-R44) [[2]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L68-R73) [[3]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L107-R108) [[4]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L123-R125) [[5]](diffhunk://#diff-2515234a7bf3cac7ccee7706f5f52b56d1aba399c120b6c79a2f455208881c3eL90-R94) [[6]](diffhunk://#diff-2515234a7bf3cac7ccee7706f5f52b56d1aba399c120b6c79a2f455208881c3eL122-R133) [[7]](diffhunk://#diff-c01a108b5fa41b9b6eee6bf0537f7b2c6dafb232acef3af4b32e0d05e7e8725aL60-R62) [[8]](diffhunk://#diff-c01a108b5fa41b9b6eee6bf0537f7b2c6dafb232acef3af4b32e0d05e7e8725aL284-R342) [[9]](diffhunk://#diff-c01a108b5fa41b9b6eee6bf0537f7b2c6dafb232acef3af4b32e0d05e7e8725aL301-R363) [[10]](diffhunk://#diff-8c132bb66f8ce0075d07f66086b9909698dee469a625e946161c28a53f40f99dL22-R22) [[11]](diffhunk://#diff-1d01643e718f913f22711cf2f091b1b00bc5d479d99d35cd055979cf4c9f1736L59-R59) [[12]](diffhunk://#diff-1d01643e718f913f22711cf2f091b1b00bc5d479d99d35cd055979cf4c9f1736L94-R100)

### Skill Detail Sensors Simplification
- Refactored skill detail sensors to use a single key per skill (e.g., `"Attack"`) instead of separate `"Attack XP"` and `"Attack Level"` keys. The sensor now stores the level as `value` and XP as an attribute, simplifying sensor creation and updates. Tests and persistence logic were updated to match this new structure. [[1]](diffhunk://#diff-ba1d521e4b0f45d9cce55941092885872478cf5b88c395150e78994427c2da87L83-R89) [[2]](diffhunk://#diff-07e399266baf3ec24923492b19d1ce9bac90e0fb70611c431c4dfbe2dbccc36aL77-R82) [[3]](diffhunk://#diff-07e399266baf3ec24923492b19d1ce9bac90e0fb70611c431c4dfbe2dbccc36aL129-R132) [[4]](diffhunk://#diff-07e399266baf3ec24923492b19d1ce9bac90e0fb70611c431c4dfbe2dbccc36aL170-R173) [[5]](diffhunk://#diff-39c7f2b4e73f8d2897f16731c170504a7a969671cf2ab3d00b4169f114964fabL67-R69) [[6]](diffhunk://#diff-39c7f2b4e73f8d2897f16731c170504a7a969671cf2ab3d00b4169f114964fabL82-R104) [[7]](diffhunk://#diff-39c7f2b4e73f8d2897f16731c170504a7a969671cf2ab3d00b4169f114964fabL166-R168) [[8]](diffhunk://#diff-af2bc79cd95352637af8c12c7f9b7f0c8ee6ddb6ff9330669aca1c1acd5119c5L44-R46) [[9]](diffhunk://#diff-af2bc79cd95352637af8c12c7f9b7f0c8ee6ddb6ff9330669aca1c1acd5119c5L58-R61)

### Test and Documentation Updates
- Updated all relevant tests, mock data, and documentation samples to reflect the new spellbook field, the prayer points field renaming, and the new skill detail sensor format. [[1]](diffhunk://#diff-8c132bb66f8ce0075d07f66086b9909698dee469a625e946161c28a53f40f99dL22-R22) [[2]](diffhunk://#diff-8c132bb66f8ce0075d07f66086b9909698dee469a625e946161c28a53f40f99dR31-R34) [[3]](diffhunk://#diff-1d01643e718f913f22711cf2f091b1b00bc5d479d99d35cd055979cf4c9f1736L59-R59) [[4]](diffhunk://#diff-1d01643e718f913f22711cf2f091b1b00bc5d479d99d35cd055979cf4c9f1736R68-R71) [[5]](diffhunk://#diff-1d01643e718f913f22711cf2f091b1b00bc5d479d99d35cd055979cf4c9f1736L94-R100) [[6]](diffhunk://#diff-07e399266baf3ec24923492b19d1ce9bac90e0fb70611c431c4dfbe2dbccc36aL77-R82) [[7]](diffhunk://#diff-07e399266baf3ec24923492b19d1ce9bac90e0fb70611c431c4dfbe2dbccc36aL129-R132) [[8]](diffhunk://#diff-07e399266baf3ec24923492b19d1ce9bac90e0fb70611c431c4dfbe2dbccc36aL170-R173) [[9]](diffhunk://#diff-39c7f2b4e73f8d2897f16731c170504a7a969671cf2ab3d00b4169f114964fabL67-R69) [[10]](diffhunk://#diff-39c7f2b4e73f8d2897f16731c170504a7a969671cf2ab3d00b4169f114964fabL82-R104) [[11]](diffhunk://#diff-39c7f2b4e73f8d2897f16731c170504a7a969671cf2ab3d00b4169f114964fabL166-R168) [[12]](diffhunk://#diff-af2bc79cd95352637af8c12c7f9b7f0c8ee6ddb6ff9330669aca1c1acd5119c5L44-R46) [[13]](diffhunk://#diff-af2bc79cd95352637af8c12c7f9b7f0c8ee6ddb6ff9330669aca1c1acd5119c5L58-R61)

These changes improve the clarity, extensibility, and consistency of the codebase and data model.