### PR TITLE
Fix JSON formatting in hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,5 @@
 {
   "name": "OSRS Data",
   "filename": "osrs_data",
-  "homeassistant": "2026.2.2",
-  "country": ["NL"]
+  "homeassistant": "2026.2.2"
 }


### PR DESCRIPTION
This pull request makes a minor update to the `hacs.json` file by removing the `country` field. The rest of the configuration remains unchanged.